### PR TITLE
Define intake.drivers entrypoints.

### DIFF
--- a/intake_xarray/__init__.py
+++ b/intake_xarray/__init__.py
@@ -2,6 +2,7 @@ from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
 
+import intake  # Import this first to avoid circular imports during discovery.
 from .netcdf import NetCDFSource
 from .opendap import OpenDapSource
 from .raster import RasterIOSource

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,16 @@ setup(
     license='BSD',
     py_modules=['intake_xarray'],
     packages=find_packages(),
+    entry_points={
+        'intake.drivers': [
+            'netcdf = intake_xarray.netcdf:NetCDFSource',
+            'zarr = intake_xarray.xzarr:ZarrSource',
+            'opendap = intake_xarray.opendap:OpenDapSource',
+            'xarray_image = intake_xarray.image:ImageSource',
+            'rasterio = intake_xarray.raster:RasterIOSource',
+            'remote-xarray = intake_xarray.xarray_container:RemoteXarray',
+        ]
+    },
     package_data={'': ['*.csv', '*.yml', '*.html']},
     include_package_data=True,
     install_requires=INSTALL_REQUIRES,

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,11 @@
+import intake
+import pytest
+
+
+def test_discovery():
+    with pytest.warns(None) as record:
+        registry = intake.autodiscover()
+    # For awhile we expect a PendingDeprecationWarning due to
+    # do_pacakge_scan=True. But we should *not* get a FutureWarning.
+    for record in record.list:
+        assert not isinstance(record.message, FutureWarning)


### PR DESCRIPTION
This PR adds support for the new driver discovery mechanism added in https://github.com/intake/intake/pull/236/. It does not change the behavior of intake-xarray with older versions of intake.