### PR TITLE
Fix array creation (arguments are wrong).

### DIFF
--- a/intake_xarray/xarray_container.py
+++ b/intake_xarray/xarray_container.py
@@ -96,6 +96,7 @@ class RemoteXarray(RemoteSource):
         this method fetches coordinates data and creates dask arrays.
         """
         import dask.array as da
+        from dask.array.utils import meta_from_array
         if self._schema is None:
             metadata = {
                 'dims': dict(self._ds.dims),
@@ -135,8 +136,13 @@ class RemoteXarray(RemoteSource):
 
                     for part in itertools.product(*nparts)
                 }
-                self._ds[var].data = da.Array(dask, name, chunks,
-                                              arr.dtype, arr.shape)
+                self._ds[var].data = da.Array(
+                    dask,
+                    name,
+                    chunks,
+                    arr.dtype,
+                    meta_from_array(arr),
+                    arr.shape)
             if self.metadata.get('array', False):
                 self._ds = self._ds[self.metadata.get('array')]
         return self._schema

--- a/intake_xarray/xarray_container.py
+++ b/intake_xarray/xarray_container.py
@@ -96,7 +96,6 @@ class RemoteXarray(RemoteSource):
         this method fetches coordinates data and creates dask arrays.
         """
         import dask.array as da
-        from dask.array.utils import meta_from_array
         if self._schema is None:
             metadata = {
                 'dims': dict(self._ds.dims),
@@ -140,9 +139,8 @@ class RemoteXarray(RemoteSource):
                     dask,
                     name,
                     chunks,
-                    arr.dtype,
-                    meta_from_array(arr),
-                    arr.shape)
+                    dtype=arr.dtype,
+                    shape=arr.shape)
             if self.metadata.get('array', False):
                 self._ds = self._ds[self.metadata.get('array')]
         return self._schema

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -41,6 +41,7 @@ def test_remote_netcdf(intake_server):
     assert source._schema is None
     source._get_schema()
     assert source._schema is not None
+    repr(source.to_dask())
     assert (source.to_dask().rh.data.compute() ==
             cat_local.xarray_source.to_dask().rh.data.compute()).all()
     assert (source.read() ==
@@ -57,6 +58,7 @@ def test_remote_tiff(intake_server):
     assert source._schema is None
     source._get_schema()
     assert source._schema is not None
+    repr(source.to_dask())
     remote = source.to_dask().data.compute()
     local = cat_local.tiff_source.to_dask().data.compute()
     assert (remote == local).all()


### PR DESCRIPTION
While using the example notebooks, @gwbischof and I noticed that displaying one of the remote, dask-backed xarrays triggered an error. This led to the discovery that the call to ``Array`` is missing the ``meta`` argument, and the parameter intended to be passed to ``shape`` is instead being passed to ``meta``.

The test in e8701cf reproduced the bug. Expand details below to see test output demonstrating the failure.

<details>

```python
______________________________________________________________________________________ test_remote_tiff ______________________________________________________________________________________

intake_server = 'intake://localhost:8425'

    def test_remote_tiff(intake_server):
        pytest.importorskip('rasterio')
        cat_local = intake.open_catalog(cat_file)
        cat = intake.open_catalog(intake_server)
        assert 'tiff_source' in cat
        source = cat.tiff_source()
        assert isinstance(source._ds, xr.Dataset)
        assert source._schema is None
        source._get_schema()
        assert source._schema is not None
>       repr(source.to_dask())

tests/test_remote.py:61: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../../venv/bnl/lib/python3.6/site-packages/xarray/core/common.py:108: in __repr__
    return formatting.array_repr(self)
../../../venv/bnl/lib/python3.6/site-packages/xarray/core/formatting.py:413: in array_repr
    summary.append(short_data_repr(arr))
../../../venv/bnl/lib/python3.6/site-packages/xarray/core/formatting.py:396: in short_data_repr
    return short_dask_repr(array)
../../../venv/bnl/lib/python3.6/site-packages/xarray/core/formatting.py:388: in short_dask_repr
    array.shape, array.dtype, chunksize)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <[AttributeError("'DataArray' object has no attribute 'dtype'") raised in repr()] DataArray object at 0x7f6ee466dda0>, name = 'dtype'

    def __getattr__(self, name: str) -> Any:
        if name != '__setstate__':
            # this avoids an infinite loop when pickle looks for the
            # __setstate__ attribute before the xarray object is initialized
            for source in self._attr_sources:
                with suppress(KeyError):
                    return source[name]
        raise AttributeError("%r object has no attribute %r" %
>                            (type(self).__name__, name))
E       AttributeError: 'DataArray' object has no attribute 'dtype'

../../../venv/bnl/lib/python3.6/site-packages/xarray/core/common.py:181: AttributeError
```

</details>

The next commit fixes the issue, confirmed by a passing test.