### PR TITLE
Fix FutureWarning in intake_xarray.netcdf.NetCDFSource()

### DIFF
--- a/intake_xarray/netcdf.py
+++ b/intake_xarray/netcdf.py
@@ -52,6 +52,8 @@ class NetCDFSource(DataSourceMixin, PatternMixin):
                 kwargs.update(concat_dim=self.concat_dim)
             if self.pattern:
                 kwargs.update(preprocess=self._add_path_to_ds)
+            if 'combine' not in kwargs.keys():
+                kwargs.update(combine='nested')
         else:
             _open_dataset = xr.open_dataset
 


### PR DESCRIPTION
This change removes the future warning:

```
FutureWarning: In xarray version 0.14 the default behaviour of `open_mfdataset`
will change. To retain the existing behavior, pass
combine='nested'. To use future default behavior, pass
combine='by_coords'. See
http://xarray.pydata.org/en/stable/combining.html#combining-multi
```

in the `intake_xarray/tests/test_intake_xarray.py` unit test. Issue is documented in https://github.com/intake/intake-xarray/issues/54.