### PR TITLE
Allow for no authentication and NASA Earthdata (URS) authentication for OPeNDAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ data drivers included in this package.
 In `intake-xarray`, there are plugins provided for reading data into [xarray](http://xarray.pydata.org/en/stable/) 
 containers:
   - NetCDF
+  - OPeNDAP
   - Rasterio
   - Zarr
   - images
@@ -28,5 +29,5 @@ conda install -c conda-forge intake-xarray
 To install optional dependencies:
 
 ```
-conda install -c conda-forge rasterio
+conda install -c conda-forge pydap rasterio
 ```

--- a/ci/environment-py36-defaults.yml
+++ b/ci/environment-py36-defaults.yml
@@ -6,5 +6,6 @@ dependencies:
   - zarr
   - pytest
   - netcdf4
+  - pydap
   - rasterio
   - scikit-image

--- a/ci/environment-py36-defaults.yml
+++ b/ci/environment-py36-defaults.yml
@@ -6,6 +6,5 @@ dependencies:
   - zarr
   - pytest
   - netcdf4
-  - pydap
   - rasterio
   - scikit-image

--- a/ci/environment-py36.yml
+++ b/ci/environment-py36.yml
@@ -8,5 +8,6 @@ dependencies:
   - zarr
   - pytest
   - netcdf4
+  - pydap
   - rasterio
   - scikit-image

--- a/ci/environment-py37-nodefaults.yml
+++ b/ci/environment-py37-nodefaults.yml
@@ -9,5 +9,6 @@ dependencies:
   - zarr
   - pytest
   - netcdf4
+  - pydap
   - rasterio
   - scikit-image

--- a/intake_xarray/opendap.py
+++ b/intake_xarray/opendap.py
@@ -21,6 +21,8 @@ class OpenDapSource(DataSourceMixin):
         'esgf' - [Default] Earth System Grid Federation.
         'urs' - NASA Earthdata Login, also known as URS.
         None - No authentication.
+        Note that you will need to set your username and password respectively using the
+        environment variables DAP_USER and DAP_PASSWORD.
     """
     name = 'opendap'
 

--- a/intake_xarray/opendap.py
+++ b/intake_xarray/opendap.py
@@ -45,7 +45,8 @@ class OpenDapSource(DataSourceMixin):
                 from pydap.cas.urs import setup_session
             else:
                 raise ValueError(
-                    f"Authentication method should either be 'esgf' or 'urs', got {auth} instead."
+                    "Authentication method should either be None, 'esgf' or 'urs', "
+                    f"got '{self.auth}' instead."
                 )
             username = os.getenv('DAP_USER', None)
             password = os.getenv('DAP_PASSWORD', None)

--- a/intake_xarray/opendap.py
+++ b/intake_xarray/opendap.py
@@ -15,25 +15,41 @@ class OpenDapSource(DataSourceMixin):
         Chunks is used to load the new dataset into dask
         arrays. ``chunks={}`` loads the dataset with dask using a single
         chunk for all arrays.
+    auth: None, "esgf" or "urs"
+        Method of authenticating to the OPeNDAP server.
+        Choose from one of the following:
+        'esgf' - [Default] Earth System Grid Federation.
+        'urs' - NASA Earthdata Login, also known as URS.
+        None - No authentication.
     """
     name = 'opendap'
 
-    def __init__(self, urlpath, chunks, xarray_kwargs=None, metadata=None,
+    def __init__(self, urlpath, chunks, auth="esgf", xarray_kwargs=None, metadata=None,
                  **kwargs):
         self.urlpath = urlpath
         self.chunks = chunks
+        self.auth = auth
         self._kwargs = xarray_kwargs or kwargs
         self._ds = None
         super(OpenDapSource, self).__init__(metadata=metadata)
 
     def _get_session(self):
-        from pydap.cas.esgf import setup_session
-        username = os.getenv('DAP_USER', None)
-        password = os.getenv('DAP_PASSWORD', None)
-        return setup_session(
-            username,
-            password,
-            check_url=self.urlpath)
+        if self.auth is None:
+            session = None
+        else:
+            if self.auth == "esgf":
+                from pydap.cas.esgf import setup_session
+            elif self.auth == "urs":
+                from pydap.cas.urs import setup_session
+            else:
+                raise ValueError(
+                    f"Authentication method should either be 'esgf' or 'urs', got {auth} instead."
+                )
+            username = os.getenv('DAP_USER', None)
+            password = os.getenv('DAP_PASSWORD', None)
+            session = setup_session(username, password, check_url=self.urlpath)
+
+        return session
 
     def _open_dataset(self):
         import xarray as xr

--- a/intake_xarray/tests/data/catalog.yaml
+++ b/intake_xarray/tests/data/catalog.yaml
@@ -96,3 +96,10 @@ sources:
     driver: zarr
     args:
       urlpath: "{{CATALOG_DIR}}/blank.zarr"
+  opendap_source:
+    description: example OPeNDAP source
+    driver: opendap
+    args:
+      urlpath: http://test.opendap.org/opendap/hyrax/data/nc/data.nc
+      chunks: {}
+      auth: null

--- a/intake_xarray/tests/test_intake_xarray.py
+++ b/intake_xarray/tests/test_intake_xarray.py
@@ -303,3 +303,13 @@ def test_read_jpg_image():
     im = ImageSource(os.path.join(here, 'data', 'dog.jpg'))
     da = im.read()
     assert da.shape == (192, 192)
+
+
+def test_read_opendap_no_auth():
+    pytest.importorskip("pydap")
+    cat = intake.open_catalog(os.path.join(here, "data", "catalog.yaml"))
+    source = cat.opendap_source
+    info = source.discover()
+    assert info["metadata"]["dims"] == {"TIME": 12}
+    x = source.read()
+    assert x.TIME.shape == (12,)

--- a/intake_xarray/tests/test_intake_xarray.py
+++ b/intake_xarray/tests/test_intake_xarray.py
@@ -334,3 +334,12 @@ def test_read_opendap_with_auth(auth):
         mock_setup_session.assert_called_once_with(
             os.environ["DAP_USER"], os.environ["DAP_PASSWORD"], check_url=urlpath
         )
+
+
+def test_read_opendap_invalid_auth():
+    pytest.importorskip("pydap")
+    from intake_xarray.opendap import OpenDapSource
+
+    source = OpenDapSource(urlpath="https://test.url", chunks={}, auth="abcd")
+    with pytest.raises(ValueError):
+        source.discover()

--- a/intake_xarray/tests/test_intake_xarray.py
+++ b/intake_xarray/tests/test_intake_xarray.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 
@@ -313,3 +315,22 @@ def test_read_opendap_no_auth():
     assert info["metadata"]["dims"] == {"TIME": 12}
     x = source.read()
     assert x.TIME.shape == (12,)
+
+
+@pytest.mark.parametrize("auth", ["esgf", "urs"])
+def test_read_opendap_with_auth(auth):
+    pytest.importorskip("pydap")
+    from intake_xarray.opendap import OpenDapSource
+
+    os.environ["DAP_USER"] = "username"
+    os.environ["DAP_PASSWORD"] = "password"
+    urlpath = "http://test.opendap.org/opendap/hyrax/data/nc/123.nc"
+
+    with patch(
+        f"pydap.cas.{auth}.setup_session", return_value=None
+    ) as mock_setup_session:
+        source = OpenDapSource(urlpath=urlpath, chunks={}, auth=auth)
+        source.discover()
+        mock_setup_session.assert_called_once_with(
+            os.environ["DAP_USER"], os.environ["DAP_PASSWORD"], check_url=urlpath
+        )


### PR DESCRIPTION
Besides the default Earth System Grid Federation (ESGF) authentication method, this Pull Request also allows for NASA Earthdata Login (URS) authentication and no authentication.

TODO:
- [x] Initial setup and unit test for simple no authentication case
- [x] Add (mock?) tests for `urs` and `esgf` authentication methods
- [x] Add unit tests for invalid authentication

Links:
- https://www.pydap.org/en/latest/client.html#authentication
- https://xarray.pydata.org/en/stable/io.html#opendap
- OPeNDAP test server at http://test.opendap.org/opendap/hyrax/data/
- https://github.com/pydata/xarray/issues/1068