### PR TITLE
Allow opening of fsspec cache files

### DIFF
--- a/ci/environment-py36-defaults.yml
+++ b/ci/environment-py36-defaults.yml
@@ -8,3 +8,4 @@ dependencies:
   - netcdf4
   - rasterio
   - scikit-image
+  - pip

--- a/ci/environment-py36.yml
+++ b/ci/environment-py36.yml
@@ -8,6 +8,7 @@ dependencies:
   - zarr
   - pytest
   - netcdf4
+  - pip
   - pydap
   - rasterio
   - scikit-image

--- a/ci/environment-py37-nodefaults.yml
+++ b/ci/environment-py37-nodefaults.yml
@@ -5,10 +5,11 @@ channels:
 dependencies:
   - python=3.7
   - intake>=0.4.1
-  - xarray=0.11.0  # pinnned this low as a test
+  - xarray
   - zarr
   - pytest
   - netcdf4
+  - pip
   - pydap
   - rasterio
   - scikit-image

--- a/ci/travis/test.sh
+++ b/ci/travis/test.sh
@@ -4,6 +4,9 @@ set -e # exit on error
 echo "Creating test env"
 conda env create -n test_env --file ci/environment-${CONDA_ENV}.yml
 source activate test_env
+# dev versions
+pip install git+https://github.com/intake/filesystem_spec --no-deps
+pip install git+https://github.com/intake/intake --no-deps
 conda list
 
 echo "Installing intake_xarray."

--- a/ci/travis/test.sh
+++ b/ci/travis/test.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e # exit on error
+set -x
 
 echo "Creating test env"
 conda env create -n test_env --file ci/environment-${CONDA_ENV}.yml

--- a/intake_xarray/__init__.py
+++ b/intake_xarray/__init__.py
@@ -3,6 +3,7 @@ __version__ = get_versions()['version']
 del get_versions
 
 import intake  # Import this first to avoid circular imports during discovery.
+from intake.container import register_container
 from .netcdf import NetCDFSource
 from .opendap import OpenDapSource
 from .raster import RasterIOSource
@@ -10,7 +11,6 @@ from .xzarr import ZarrSource
 from .xarray_container import RemoteXarray
 from .image import ImageSource
 
-import intake.container
 
-intake.registry['remote-xarray'] = RemoteXarray
-intake.container.container_map['xarray'] = RemoteXarray
+intake.register_driver('remote-xarray', RemoteXarray)
+register_container('xarray', RemoteXarray)

--- a/intake_xarray/raster.py
+++ b/intake_xarray/raster.py
@@ -48,7 +48,7 @@ class RasterIOSource(DataSourceMixin, PatternMixin):
         self.urlpath = urlpath
         self.chunks = chunks
         self.dim = concat_dim
-        self.storage_options = storage_options
+        self.storage_options = storage_options or {}
         self._kwargs = xarray_kwargs or {}
         self._ds = None
         super(RasterIOSource, self).__init__(metadata=metadata)

--- a/intake_xarray/raster.py
+++ b/intake_xarray/raster.py
@@ -75,7 +75,7 @@ class RasterIOSource(DataSourceMixin, PatternMixin):
     def _open_dataset(self):
         import xarray as xr
         files = fsspec.open_local(self.urlpath, **self.storage_options)
-        if isinstance(self.urlpath, list):
+        if isinstance(self.urlpath, list) or len(files) > 1:
             self._ds = self._open_files(files)
         else:
             self._ds = xr.open_rasterio(files[0], chunks=self.chunks,

--- a/intake_xarray/raster.py
+++ b/intake_xarray/raster.py
@@ -78,7 +78,7 @@ class RasterIOSource(DataSourceMixin, PatternMixin):
         if isinstance(self.urlpath, list):
             self._ds = self._open_files(files)
         else:
-            self._ds = xr.open_rasterio(files, chunks=self.chunks,
+            self._ds = xr.open_rasterio(files[0], chunks=self.chunks,
                                         **self._kwargs)
 
     def _get_schema(self):

--- a/intake_xarray/raster.py
+++ b/intake_xarray/raster.py
@@ -75,10 +75,10 @@ class RasterIOSource(DataSourceMixin, PatternMixin):
     def _open_dataset(self):
         import xarray as xr
         files = fsspec.open_local(self.urlpath, **self.storage_options)
-        if isinstance(self.urlpath, list) or len(files) > 1:
+        if isinstance(files, list):
             self._ds = self._open_files(files)
         else:
-            self._ds = xr.open_rasterio(files[0], chunks=self.chunks,
+            self._ds = xr.open_rasterio(files, chunks=self.chunks,
                                         **self._kwargs)
 
     def _get_schema(self):

--- a/intake_xarray/tests/test_intake_xarray.py
+++ b/intake_xarray/tests/test_intake_xarray.py
@@ -60,21 +60,6 @@ def test_read_list_of_netcdf_files():
                       'concat_dim': 2}
 
 
-def test_cached_list_netcdf():
-    tempd = str(tempfile.mkdtemp())
-    from intake_xarray.netcdf import NetCDFSource
-    source = NetCDFSource([
-        'filecache://' + os.path.join(here, 'data', 'example_1.nc'),
-        'filecache://' + os.path.join(here, 'data', 'example_2.nc'),
-        ],
-        storage_options={'cache_storage': tempd, 'target_protocol': 'file'}
-    )
-    d = source.to_dask()
-    assert d.dims == {'lat': 5, 'lon': 10, 'level': 4, 'time': 1,
-                      'concat_dim': 2}
-    assert os.listdir(tempd)
-
-
 def test_read_glob_pattern_of_netcdf_files():
     """If xarray is old, prompt user to update to use pattern"""
     from intake_xarray.netcdf import NetCDFSource
@@ -359,3 +344,18 @@ def test_read_opendap_invalid_auth():
     source = OpenDapSource(urlpath="https://test.url", chunks={}, auth="abcd")
     with pytest.raises(ValueError):
         source.discover()
+
+
+def test_cached_list_netcdf():
+    tempd = str(tempfile.mkdtemp())
+    from intake_xarray.netcdf import NetCDFSource
+    source = NetCDFSource([
+        'filecache://' + os.path.join(here, 'data', 'example_1.nc'),
+        'filecache://' + os.path.join(here, 'data', 'example_2.nc'),
+        ],
+        storage_options={'cache_storage': tempd, 'target_protocol': 'file'}
+    )
+    d = source.to_dask()
+    assert d.dims == {'lat': 5, 'lon': 10, 'level': 4, 'time': 1,
+                      'concat_dim': 2}
+    assert os.listdir(tempd)

--- a/intake_xarray/tests/test_intake_xarray.py
+++ b/intake_xarray/tests/test_intake_xarray.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 from unittest.mock import patch
+import tempfile
 
 import numpy as np
 import pytest
@@ -57,6 +58,23 @@ def test_read_list_of_netcdf_files():
     d = source.to_dask()
     assert d.dims == {'lat': 5, 'lon': 10, 'level': 4, 'time': 1,
                       'concat_dim': 2}
+
+
+def test_cached_list_netcdf():
+    tempd = str(tempfile.mkdtemp())
+    from intake_xarray.netcdf import NetCDFSource
+    source = NetCDFSource([
+        'filecache://' + os.path.join(here, 'data', 'example_1.nc'),
+        'filecache://' + os.path.join(here, 'data', 'example_2.nc'),
+        ],
+        storage_options={'cache_storage': tempd, 'target_protocol': 'file'}
+    )
+    d = source.to_dask()
+    assert d.dims == {'lat': 5, 'lon': 10, 'level': 4, 'time': 1,
+                      'concat_dim': 2}
+    import pdb
+    pdb.set_trace()
+    assert os.listdir(tempd)
 
 
 def test_read_glob_pattern_of_netcdf_files():

--- a/intake_xarray/tests/test_intake_xarray.py
+++ b/intake_xarray/tests/test_intake_xarray.py
@@ -72,8 +72,6 @@ def test_cached_list_netcdf():
     d = source.to_dask()
     assert d.dims == {'lat': 5, 'lon': 10, 'level': 4, 'time': 1,
                       'concat_dim': 2}
-    import pdb
-    pdb.set_trace()
     assert os.listdir(tempd)
 
 


### PR DESCRIPTION
@jsignell , you might be interested. The intent is to allow caching files and opening locally with resterio/netcdf, using fsspec mechanisms only (i.e., replacing the poorly-understood Intake mechanism, which remains available for now).