### PR TITLE
test catalog: engine should be in xarray_kwargs

### DIFF
--- a/intake_xarray/tests/data/catalog.yaml
+++ b/intake_xarray/tests/data/catalog.yaml
@@ -13,7 +13,8 @@ sources:
     driver: netcdf
     args:
       urlpath: '{{ CATALOG_DIR }}/waf*.grib2'
-      engine: pynio
+      xarray_kwargs:
+        engine: pynio
       chunks:
         lv_ISBL0: 2
       combine: nested


### PR DESCRIPTION
As discussed in #72, this may have always been a bug but hasn't been
triggered before.