### PR TITLE
opendap driver: use no authentication as default

### DIFF
--- a/intake_xarray/opendap.py
+++ b/intake_xarray/opendap.py
@@ -38,7 +38,7 @@ class OpenDapSource(DataSourceMixin):
     """
     name = 'opendap'
 
-    def __init__(self, urlpath, chunks, auth="esgf", xarray_kwargs=None, metadata=None,
+    def __init__(self, urlpath, chunks, auth=None, xarray_kwargs=None, metadata=None,
                  **kwargs):
         self.urlpath = urlpath
         self.chunks = chunks

--- a/intake_xarray/opendap.py
+++ b/intake_xarray/opendap.py
@@ -29,7 +29,8 @@ class OpenDapSource(DataSourceMixin):
     auth: None, "esgf" or "urs"
         Method of authenticating to the OPeNDAP server.
         Choose from one of the following:
-        'esgf' - [Default] Earth System Grid Federation.
+        None - [Default] Anonymous access.
+        'esgf' - Earth System Grid Federation.
         'urs' - NASA Earthdata Login, also known as URS.
         'generic_http' - OPeNDAP servers which support plain HTTP authentication
         None - No authentication.


### PR DESCRIPTION
Apart from historic reasons, using ESGF as the default authentication method does not seem to be a straight forward choice. Changing the default to no authentication most likely is the more user friendly alternative. Apart from that and following #57, the default if no authentication method is given should be anonymous access, but currently this fall back does not work (see also #74).

Be aware that this change may break other catalogs if they use ESGF and rely on the behaviour of using ESGF even if it is not specified in the catalog. If this is not an option, please feel free to reject the PR.