### PR TITLE
opendap driver: make chunks argument optional

### DIFF
--- a/intake_xarray/opendap.py
+++ b/intake_xarray/opendap.py
@@ -22,7 +22,7 @@ class OpenDapSource(DataSourceMixin):
     ----------
     urlpath: str
         Path to source file.
-    chunks: int or dict
+    chunks: None, int or dict
         Chunks is used to load the new dataset into dask
         arrays. ``chunks={}`` loads the dataset with dask using a single
         chunk for all arrays.

--- a/intake_xarray/opendap.py
+++ b/intake_xarray/opendap.py
@@ -38,7 +38,7 @@ class OpenDapSource(DataSourceMixin):
     """
     name = 'opendap'
 
-    def __init__(self, urlpath, chunks, auth="esgf", xarray_kwargs=None, metadata=None,
+    def __init__(self, urlpath, chunks=None, auth="esgf", xarray_kwargs=None, metadata=None,
                  **kwargs):
         self.urlpath = urlpath
         self.chunks = chunks


### PR DESCRIPTION
The xarray.open_dataset function allows `None` as a `chunks` specification. This changed allows this as well for the opendap driver
and thus makes the `chunks` argument in the catalog optional.