### PR TITLE
fix autodiscover test

### DIFF
--- a/intake_xarray/tests/test_discovery.py
+++ b/intake_xarray/tests/test_discovery.py
@@ -1,10 +1,10 @@
-import intake
+import intake.source.discovery
 import pytest
 
 
 def test_discovery():
     with pytest.warns(None) as record:
-        registry = intake.autodiscover()
+        registry = intake.source.discovery.autodiscover()
     # For awhile we expect a PendingDeprecationWarning due to
     # do_pacakge_scan=True. But we should *not* get a FutureWarning.
     for record in record.list:


### PR DESCRIPTION
With https://github.com/intake/intake/pull/526, `autodiscover` can not
be imported directly from the intake module anymore.