### PR TITLE
Reads multiple zarr files

### DIFF
--- a/intake_xarray/xzarr.py
+++ b/intake_xarray/xzarr.py
@@ -39,7 +39,8 @@ class ZarrSource(DataSourceMixin):
                 kwargs.update(concat_dim=self.concat_dim)
         else:
             _open_dataset = xr.open_dataset
-            self._mapper = get_mapper(self.urlpath, **self.storage_options)
+            # self._mapper = get_mapper(self.urlpath, **self.storage_options)
+            self._mapper = self.urlpath
         self._ds = _open_dataset(self._mapper, chunks=self.chunks, **kwargs)
 
     def close(self):

--- a/intake_xarray/xzarr.py
+++ b/intake_xarray/xzarr.py
@@ -33,7 +33,7 @@ class ZarrSource(DataSourceMixin):
         kwargs = self._kwargs
         _open_zarr = xr._open_dataset
         self._mapper = get_mapper(self.urlpath, **self.storage_options)
-        self._ds = _open_zarr(self._mapper, chunks=self.chunks, **kwargs)
+        self._ds = _open_zarr(self._mapper, chunks=self.chunks, engine=name, **kwargs)
 
     def close(self):
         super(ZarrSource, self).close()

--- a/intake_xarray/xzarr.py
+++ b/intake_xarray/xzarr.py
@@ -16,7 +16,7 @@ class ZarrSource(DataSourceMixin):
     """
     name = 'zarr'
 
-    def __init__(self, urlpath, chunks=None, concat_dim='concat_dim',
+    def __init__(self, urlpath, chunks="auto", concat_dim='concat_dim',
                  xarray_kwargs=None, storage_options=None, metadata=None,
                  **kwargs):
         self.urlpath = urlpath

--- a/intake_xarray/xzarr.py
+++ b/intake_xarray/xzarr.py
@@ -42,13 +42,13 @@ class ZarrSource(DataSourceMixin, PatternMixin):
             if 'combine' not in kwargs.keys():
                 print('here')
                 kwargs.update(combine='nested')
-            import fsspec
-            url = fsspec.open_local(url, **self.storage_options)
-            self._ds = _open_zarr(url, chunks=self.chunks, **kwargs)
-        else:
+            # import fsspec
+        #     url = fsspec.open_local(url, **self.storage_options)
+        #     self._ds = _open_zarr(url, chunks=self.chunks, **kwargs)
+        # else:
             _open_zarr = xr.open_zarr
-            self._mapper = get_mapper(self.urlpath, **self.storage_options)
-            self._ds = _open_zarr(self._mapper, chunks=self.chunks, **kwargs)
+        self._mapper = get_mapper(self.urlpath, **self.storage_options)
+        self._ds = _open_zarr(self._mapper, chunks=self.chunks, **kwargs)
 
     def close(self):
         super(ZarrSource, self).close()

--- a/intake_xarray/xzarr.py
+++ b/intake_xarray/xzarr.py
@@ -39,6 +39,8 @@ class ZarrSource(DataSourceMixin):
             if 'combine' not in kwargs.keys():
                 print('here')
                 kwargs.update(combine='nested')
+            # get_mapper does not recognize glob-like paths, but
+            # it works just to simply pass the path directly to xarray
             self._mapper = url
         else:
             _open_zarr = xr.open_zarr

--- a/intake_xarray/xzarr.py
+++ b/intake_xarray/xzarr.py
@@ -1,6 +1,6 @@
 from .base import DataSourceMixin
 from intake.source.base import PatternMixin
-
+from glob import glob
 
 class ZarrSource(DataSourceMixin, PatternMixin):
     """Open a xarray dataset.
@@ -42,9 +42,10 @@ class ZarrSource(DataSourceMixin, PatternMixin):
             if 'combine' not in kwargs.keys():
                 print('here')
                 kwargs.update(combine='nested')
+            self._mapper = glob(url)
         else:
             _open_zarr = xr.open_zarr
-        self._mapper = get_mapper(self.urlpath, **self.storage_options)
+            self._mapper = get_mapper(self.urlpath, **self.storage_options)
         self._ds = _open_zarr(self._mapper, chunks=self.chunks, **kwargs)
 
     def close(self):

--- a/intake_xarray/xzarr.py
+++ b/intake_xarray/xzarr.py
@@ -31,7 +31,7 @@ class ZarrSource(DataSourceMixin):
         import xarray as xr
         from fsspec import get_mapper
         kwargs = self._kwargs
-        if "*" in self.url or isinstance(self.urlpath, list):
+        if "*" in self.urlpath or isinstance(self.urlpath, list):
             _open_dataset = xr.open_mfdataset
             self._mapper = self.urlpath
             if 'concat_dim' not in kwargs.keys():

--- a/intake_xarray/xzarr.py
+++ b/intake_xarray/xzarr.py
@@ -16,9 +16,9 @@ class ZarrSource(DataSourceMixin):
     """
     name = 'zarr'
 
-    def __init__(self, urlpath, chunks="auto", concat_dim='concat_dim',
-                 xarray_kwargs=None, storage_options=None, metadata=None,
-                 **kwargs):
+    def __init__(self, urlpath, engine='zarr', chunks="auto",
+                 concat_dim='concat_dim', xarray_kwargs=None,
+                 storage_options=None, metadata=None, **kwargs):
         self.urlpath = urlpath
         self.chunks = chunks
         self.concat_dim = concat_dim
@@ -33,14 +33,13 @@ class ZarrSource(DataSourceMixin):
         kwargs = self._kwargs
         if "*" in self.urlpath or isinstance(self.urlpath, list):
             _open_dataset = xr.open_mfdataset
-            self._mapper = self.urlpath
+            self._mapper = self.urlpath  # pass directly the glob
             if 'concat_dim' not in kwargs.keys():
                 kwargs.update(concat_dim=self.concat_dim)
         else:
             _open_dataset = xr.open_dataset
             self._mapper = get_mapper(self.urlpath, **self.storage_options)
-        self._ds = _open_dataset(self._mapper, chunks=self.chunks,
-                                 engine="zarr", **kwargs)
+        self._ds = _open_dataset(self._mapper, chunks=self.chunks, **kwargs)
 
     def close(self):
         super(ZarrSource, self).close()

--- a/intake_xarray/xzarr.py
+++ b/intake_xarray/xzarr.py
@@ -33,7 +33,7 @@ class ZarrSource(DataSourceMixin):
         url = self.urlpath
         kwargs = self._kwargs
         if "*" in url or isinstance(url, list):
-            _open_zarr = xr.open_mzarr
+            _open_zarr = xr.open_mfdataset
             if 'concat_dim' not in kwargs.keys():
                 kwargs.update(concat_dim=self.concat_dim)
             if 'combine' not in kwargs.keys():

--- a/intake_xarray/xzarr.py
+++ b/intake_xarray/xzarr.py
@@ -30,21 +30,9 @@ class ZarrSource(DataSourceMixin):
     def _open_dataset(self):
         import xarray as xr
         from fsspec import get_mapper
-        url = self.urlpath
         kwargs = self._kwargs
-        if "*" in url or isinstance(url, list):
-            _open_zarr = xr.open_mfdataset
-            if 'concat_dim' not in kwargs.keys():
-                kwargs.update(concat_dim=self.concat_dim)
-            if 'combine' not in kwargs.keys():
-                print('here')
-                kwargs.update(combine='nested')
-            # get_mapper does not recognize glob-like paths, but
-            # it works just to simply pass the path directly to xarray
-            self._mapper = url
-        else:
-            _open_zarr = xr.open_zarr
-            self._mapper = get_mapper(self.urlpath, **self.storage_options)
+        _open_zarr = xr._open_dataset
+        self._mapper = get_mapper(self.urlpath, **self.storage_options)
         self._ds = _open_zarr(self._mapper, chunks=self.chunks, **kwargs)
 
     def close(self):

--- a/intake_xarray/xzarr.py
+++ b/intake_xarray/xzarr.py
@@ -38,10 +38,13 @@ class ZarrSource(DataSourceMixin):
                 kwargs.update(concat_dim=self.concat_dim)
             if 'combine' not in kwargs.keys():
                 kwargs.update(combine='nested')
+            import fsspec
+            url = fsspec.open_local(url, **self.storage_options)
+            self._ds = _open_zarr(url, chunks=self.chunks, **kwargs)
         else:
             _open_zarr = xr.open_zarr
-        self._mapper = get_mapper(self.urlpath, **self.storage_options)
-        self._ds = _open_zarr(self._mapper, chunks=self.chunks, **kwargs)
+            self._mapper = get_mapper(self.urlpath, **self.storage_options)
+            self._ds = _open_zarr(self._mapper, chunks=self.chunks, **kwargs)
 
     def close(self):
         super(ZarrSource, self).close()

--- a/intake_xarray/xzarr.py
+++ b/intake_xarray/xzarr.py
@@ -42,10 +42,7 @@ class ZarrSource(DataSourceMixin, PatternMixin):
             if 'combine' not in kwargs.keys():
                 print('here')
                 kwargs.update(combine='nested')
-            # import fsspec
-        #     url = fsspec.open_local(url, **self.storage_options)
-        #     self._ds = _open_zarr(url, chunks=self.chunks, **kwargs)
-        # else:
+        else:
             _open_zarr = xr.open_zarr
         self._mapper = get_mapper(self.urlpath, **self.storage_options)
         self._ds = _open_zarr(self._mapper, chunks=self.chunks, **kwargs)

--- a/intake_xarray/xzarr.py
+++ b/intake_xarray/xzarr.py
@@ -42,7 +42,7 @@ class ZarrSource(DataSourceMixin, PatternMixin):
             if 'combine' not in kwargs.keys():
                 print('here')
                 kwargs.update(combine='nested')
-            self._mapper = glob(url)
+            self._mapper = url
         else:
             _open_zarr = xr.open_zarr
             self._mapper = get_mapper(self.urlpath, **self.storage_options)

--- a/intake_xarray/xzarr.py
+++ b/intake_xarray/xzarr.py
@@ -1,8 +1,7 @@
 from .base import DataSourceMixin
-from intake.source.base import PatternMixin
-from glob import glob
 
-class ZarrSource(DataSourceMixin, PatternMixin):
+
+class ZarrSource(DataSourceMixin):
     """Open a xarray dataset.
 
     Parameters
@@ -18,10 +17,8 @@ class ZarrSource(DataSourceMixin, PatternMixin):
     name = 'zarr'
 
     def __init__(self, urlpath, chunks=None, concat_dim='concat_dim',
-                 xarray_kwargs=None, path_as_pattern=True,
-                 storage_options=None, metadata=None,
+                 xarray_kwargs=None, storage_options=None, metadata=None,
                  **kwargs):
-        self.path_as_pattern = path_as_pattern
         self.urlpath = urlpath
         self.chunks = chunks
         self.concat_dim = concat_dim

--- a/intake_xarray/xzarr.py
+++ b/intake_xarray/xzarr.py
@@ -32,7 +32,8 @@ class ZarrSource(DataSourceMixin):
         from fsspec import get_mapper
         kwargs = self._kwargs
         self._mapper = get_mapper(self.urlpath, **self.storage_options)
-        self._ds = xr.open_dataset(self._mapper, chunks=self.chunks, engine=name, **kwargs)
+        self._ds = xr.open_dataset(self._mapper, chunks=self.chunks,
+                                   engine="zarr", **kwargs)
 
     def close(self):
         super(ZarrSource, self).close()

--- a/intake_xarray/xzarr.py
+++ b/intake_xarray/xzarr.py
@@ -31,9 +31,8 @@ class ZarrSource(DataSourceMixin):
         import xarray as xr
         from fsspec import get_mapper
         kwargs = self._kwargs
-        _open_zarr = xr._open_dataset
         self._mapper = get_mapper(self.urlpath, **self.storage_options)
-        self._ds = _open_zarr(self._mapper, chunks=self.chunks, engine=name, **kwargs)
+        self._ds = xr.open_dataset(self._mapper, chunks=self.chunks, engine=name, **kwargs)
 
     def close(self):
         super(ZarrSource, self).close()

--- a/intake_xarray/xzarr.py
+++ b/intake_xarray/xzarr.py
@@ -1,7 +1,8 @@
 from .base import DataSourceMixin
+from intake.source.base import PatternMixin
 
 
-class ZarrSource(DataSourceMixin):
+class ZarrSource(DataSourceMixin, PatternMixin):
     """Open a xarray dataset.
 
     Parameters
@@ -17,15 +18,17 @@ class ZarrSource(DataSourceMixin):
     name = 'zarr'
 
     def __init__(self, urlpath, chunks=None, concat_dim='concat_dim',
-                 xarray_kwargs=None, storage_options=None, metadata=None,
+                 xarray_kwargs=None, path_as_pattern=True,
+                 storage_options=None, metadata=None,
                  **kwargs):
-        super(ZarrSource, self).__init__(metadata=metadata, **kwargs)
+        self.path_as_pattern = path_as_pattern
         self.urlpath = urlpath
         self.chunks = chunks
         self.concat_dim = concat_dim
         self.storage_options = storage_options or {}
         self._kwargs = xarray_kwargs or {}
         self._ds = None
+        super(ZarrSource, self).__init__(metadata=metadata, **kwargs)
 
     def _open_dataset(self):
         import xarray as xr
@@ -37,6 +40,7 @@ class ZarrSource(DataSourceMixin):
             if 'concat_dim' not in kwargs.keys():
                 kwargs.update(concat_dim=self.concat_dim)
             if 'combine' not in kwargs.keys():
+                print('here')
                 kwargs.update(combine='nested')
             import fsspec
             url = fsspec.open_local(url, **self.storage_options)

--- a/intake_xarray/xzarr.py
+++ b/intake_xarray/xzarr.py
@@ -41,7 +41,7 @@ class ZarrSource(DataSourceMixin):
         else:
             _open_zarr = xr.open_zarr
         self._mapper = get_mapper(self.urlpath, **self.storage_options)
-        self._ds = _open_zarr(self._mapper, **self.kwargs)
+        self._ds = _open_zarr(self._mapper, chunks=self.chunks, **kwargs)
 
     def close(self):
         super(ZarrSource, self).close()

--- a/intake_xarray/xzarr.py
+++ b/intake_xarray/xzarr.py
@@ -32,6 +32,8 @@ class ZarrSource(DataSourceMixin):
         import xarray as xr
         from fsspec import get_mapper
         kwargs = self._kwargs
+        if self.engine not in kwargs.keys():
+            kwargs.update(engine=self.engine)
         if "*" in self.urlpath or isinstance(self.urlpath, list):
             _open_dataset = xr.open_mfdataset
             self._mapper = self.urlpath  # pass directly the glob

--- a/intake_xarray/xzarr.py
+++ b/intake_xarray/xzarr.py
@@ -20,6 +20,7 @@ class ZarrSource(DataSourceMixin):
                  concat_dim='concat_dim', xarray_kwargs=None,
                  storage_options=None, metadata=None, **kwargs):
         self.urlpath = urlpath
+        self.engine = engine
         self.chunks = chunks
         self.concat_dim = concat_dim
         self.storage_options = storage_options or {}

--- a/intake_xarray/xzarr.py
+++ b/intake_xarray/xzarr.py
@@ -32,17 +32,16 @@ class ZarrSource(DataSourceMixin):
         import xarray as xr
         from fsspec import get_mapper
         kwargs = self._kwargs
-        if self.engine not in kwargs.keys():
-            kwargs.update(engine=self.engine)
         if "*" in self.urlpath or isinstance(self.urlpath, list):
+            if self.engine not in kwargs.keys():
+                kwargs.update(engine=self.engine)
             _open_dataset = xr.open_mfdataset
             self._mapper = self.urlpath  # pass directly the glob
             if 'concat_dim' not in kwargs.keys():
                 kwargs.update(concat_dim=self.concat_dim)
         else:
-            _open_dataset = xr.open_dataset
-            # self._mapper = get_mapper(self.urlpath, **self.storage_options)
-            self._mapper = self.urlpath
+            _open_dataset = xr.open_zarr
+            self._mapper = get_mapper(self.urlpath, **self.storage_options)
         self._ds = _open_dataset(self._mapper, chunks=self.chunks, **kwargs)
 
     def close(self):


### PR DESCRIPTION
Closes #70 

There were a couple of permutations with the new added capabilities in xarray. For now, this added code makes it possible for intake to:

1. When a single zarr file needs to be read, it still uses ```xr.open_zarr```, as before, and the get_mapper option for the ```url_path``` as before. Another option is to use ```xr.open_dataset``` and use ```fspec.open_local```, as it does in the ```netcdf``` case. I don't know enough to justify choosing between one or the other (```xr.open_zarr``` is not being deprecated anymore), I just decided to still use ```xr.open_zarr``` for simplicity (no code change there). 


2. When multiple zarr files, a glob-path like ```/directoryA/subdir*/subsub*/*``` can be passed directly to ```xr.open_mfdataset```. In such case, the code makes sure that ```engine='zarr'``` is passed as an argument.

In both cases, ```chunk='auto'``` is set as the default.  



