### PR TITLE
Logic for remote versus local filepaths for RasterIOSource + GitHub Actions CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,7 +24,7 @@ jobs:
           auto-update-conda: true
           auto-activate-base: false
           activate-environment: test_env
-          environment-file: ci/environment-${{ matrix.CONDA_ENV }}.yml
+          environment-file: ci/environment-py${{ matrix.CONDA_ENV }}.yml
 
       - name: Development Install Intake-Xarray
         shell: bash -l {0}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,12 +8,12 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.CONDA_ENV }}-build
+    name: ${{ matrix.CONDA_ENV }}-pytest
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        CONDA_ENV: [36, 36-defaults, 37-nodefaults, 37-upstream]
+        CONDA_ENV: [36, 37, 38, 37-upstream]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: "*"
+  pull_request:
+    branches: master
+
+jobs:
+  test:
+    name: ${{ matrix.CONDA_ENV }}-build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        CONDA_ENV: [36, 36-defaults, 37-nodefaults]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v1
+        with:
+          auto-update-conda: true
+          auto-activate-base: false
+          activate-environment: test_env
+          environment-file: ci/environment-${{ matrix.CONDA_ENV }}.yml
+
+      - name: Development Install Intake-Xarray
+        shell: bash -l {0}
+        run: |
+          python -m pip install --no-deps -e .
+          conda list
+
+      - name: Run Tests
+        shell: bash -l {0}
+        run: |
+          pytest --verbose

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        CONDA_ENV: [36, 36-defaults, 37-nodefaults]
+        CONDA_ENV: [36, 36-defaults, 37-nodefaults, 37-upstream]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -24,7 +24,7 @@ jobs:
           auto-update-conda: true
           auto-activate-base: false
           activate-environment: test_env
-          environment-file: ci/environment-py${{ matrix.CONDA_ENV }}.yml
+          environment-file: ci/environment-${{ matrix.CONDA_ENV }}.yml
 
       - name: Development Install Intake-Xarray
         shell: bash -l {0}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # intake-xarray
 
-[![Build Status](https://travis-ci.org/intake/intake-xarray.svg?branch=master)](https://travis-ci.org/intake/intake-xarray)
+![CI](https://github.com/intake/intake-xarray/workflows/CI/badge.svg)
 
 Intake-xarray: xarray Plugin for [Intake](https://github.com/intake/intake)
 

--- a/ci/environment-py36-defaults.yml
+++ b/ci/environment-py36-defaults.yml
@@ -1,11 +1,12 @@
 name: test_env
 dependencies:
   - python=3.6
+  - aiohttp
   - intake
-  - xarray
-  - zarr
-  - pytest
   - netcdf4
+  - pip
+  - pytest
   - rasterio
   - scikit-image
-  - pip
+  - xarray
+  - zarr

--- a/ci/environment-py36.yml
+++ b/ci/environment-py36.yml
@@ -4,12 +4,12 @@ channels:
 dependencies:
   - python=3.6
   - aiohttp
-  - intake>=0.4.1
+  - intake
   - netcdf4
   - pip
   - pydap
   - pytest
   - rasterio
   - scikit-image
-  - xarray>=0.11.2
+  - xarray
   - zarr

--- a/ci/environment-py36.yml
+++ b/ci/environment-py36.yml
@@ -13,3 +13,5 @@ dependencies:
   - scikit-image
   - xarray
   - zarr
+  - pip:
+       - rangehttpserver

--- a/ci/environment-py36.yml
+++ b/ci/environment-py36.yml
@@ -3,12 +3,13 @@ channels:
   - conda-forge
 dependencies:
   - python=3.6
+  - aiohttp
   - intake>=0.4.1
-  - xarray>=0.11.2
-  - zarr
-  - pytest
   - netcdf4
   - pip
   - pydap
+  - pytest
   - rasterio
   - scikit-image
+  - xarray>=0.11.2
+  - zarr

--- a/ci/environment-py37-upstream.yml
+++ b/ci/environment-py37-upstream.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - python=3.7
-  - intake>=0.4.1
+  - aiohttp
   - netcdf4
   - pip
   - pydap
@@ -13,3 +13,6 @@ dependencies:
   - scikit-image
   - xarray
   - zarr
+  - pip:
+       - git+https://github.com/intake/filesystem_spec.git
+       - git+https://github.com/intake/intake.git

--- a/ci/environment-py37-upstream.yml
+++ b/ci/environment-py37-upstream.yml
@@ -16,3 +16,4 @@ dependencies:
   - pip:
        - git+https://github.com/intake/filesystem_spec.git
        - git+https://github.com/intake/intake.git
+       - rangehttpserver

--- a/ci/environment-py37-upstream.yml
+++ b/ci/environment-py37-upstream.yml
@@ -1,7 +1,6 @@
 name: test_env
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - python=3.7
   - aiohttp

--- a/ci/environment-py37.yml
+++ b/ci/environment-py37.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.7
+  - aiohttp
   - intake
   - netcdf4
   - pip
@@ -12,3 +13,5 @@ dependencies:
   - scikit-image
   - xarray
   - zarr
+  - pip:
+       - rangehttpserver

--- a/ci/environment-py37.yml
+++ b/ci/environment-py37.yml
@@ -1,10 +1,12 @@
 name: test_env
+channels:
+  - conda-forge
 dependencies:
-  - python=3.6
-  - aiohttp
+  - python=3.7
   - intake
   - netcdf4
   - pip
+  - pydap
   - pytest
   - rasterio
   - scikit-image

--- a/ci/environment-py38.yml
+++ b/ci/environment-py38.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.8
+  - aiohttp
   - intake
   - netcdf4
   - pip
@@ -12,3 +13,5 @@ dependencies:
   - scikit-image
   - xarray
   - zarr
+  - pip:
+       - rangehttpserver

--- a/ci/environment-py38.yml
+++ b/ci/environment-py38.yml
@@ -1,10 +1,9 @@
 name: test_env
 channels:
   - conda-forge
-  - defaults
 dependencies:
-  - python=3.7
-  - intake>=0.4.1
+  - python=3.8
+  - intake
   - netcdf4
   - pip
   - pydap

--- a/intake_xarray/raster.py
+++ b/intake_xarray/raster.py
@@ -51,6 +51,10 @@ class RasterIOSource(DataSourceMixin, PatternMixin):
         self.storage_options = storage_options or {}
         self._kwargs = xarray_kwargs or {}
         self._ds = None
+        if isinstance(self.urlpath, list):
+            self._can_be_local = fsspec.utils.can_be_local(self.urlpath[0])
+        else:
+            self._can_be_local = fsspec.utils.can_be_local(self.urlpath)
         super(RasterIOSource, self).__init__(metadata=metadata)
 
     def _open_files(self, files):
@@ -74,7 +78,10 @@ class RasterIOSource(DataSourceMixin, PatternMixin):
 
     def _open_dataset(self):
         import xarray as xr
-        files = fsspec.open_local(self.urlpath, **self.storage_options)
+        if self._can_be_local:
+            files = fsspec.open_local(self.urlpath, **self.storage_options)
+        else:
+            files = self.urlpath
         if isinstance(files, list):
             self._ds = self._open_files(files)
         else:

--- a/intake_xarray/tests/test_intake_xarray.py
+++ b/intake_xarray/tests/test_intake_xarray.py
@@ -19,7 +19,6 @@ def test_discover(source, netcdf_source, zarr_source, dataset):
     assert r['dtype'] is None
     assert r['metadata'] is not None
 
-    assert source.datashape is None
     assert source.metadata['dims'] == dict(dataset.dims)
     assert set(source.metadata['data_vars']) == set(dataset.data_vars.keys())
     assert set(source.metadata['coords']) == set(dataset.coords.keys())

--- a/intake_xarray/tests/test_intake_xarray.py
+++ b/intake_xarray/tests/test_intake_xarray.py
@@ -16,7 +16,6 @@ def test_discover(source, netcdf_source, zarr_source, dataset):
     source = {'netcdf': netcdf_source, 'zarr': zarr_source}[source]
     r = source.discover()
 
-    assert r['datashape'] is None
     assert r['dtype'] is None
     assert r['metadata'] is not None
 

--- a/intake_xarray/tests/test_remote.py
+++ b/intake_xarray/tests/test_remote.py
@@ -44,11 +44,11 @@ def test_list(data_server):
     assert data_server+'/RGB.byte.tif' in out
 
 
-def test_read_remote_tif(data_server):
+def test_open_rasterio(data_server):
     url = f'{data_server}/RGB.byte.tif'
     source = intake.open_rasterio(url, chunks={})
     da = source.to_dask()
-    assert isintance(da, xarray.core.dataarray.DataArray)
+    assert isinstance(da, xr.core.dataarray.DataArray)
 
 
 # Remote catalogs with intake-server

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@
 from setuptools import setup, find_packages
 import versioneer
 
-INSTALL_REQUIRES = ['intake >=0.5.2', 'xarray >=0.12.0', 'zarr', 'dask >=2.2', 'netcdf4']
+INSTALL_REQUIRES = ['intake >=0.5.2', 'xarray >=0.12.0', 'zarr', 'dask >=2.2', 'netcdf4', 'fsspec>0.8.3']
 
 setup(
     name='intake-xarray',


### PR DESCRIPTION
Working towards a fix for #81. 

@martindurant and @d70-t , I'm pretty new to setting up test servers, so feel free to take over this PR.
 But I felt like I made a bit of progress today and wanted to open this up. 

Currently my `test_read_remote_tif` function fails with `E   rasterio.errors.RasterioIOError: Range downloading not supported by this server!`, which I'm not sure how to deal with.  This seems to be a local setup issue because reading from github works fine:
```
with rasterio.open('https://raw.githubusercontent.com/intake/intake-xarray/master/intake_xarray/tests/data/RGB.byte.tif') as src:
    print(src.profile)
# {'driver': 'GTiff', 'dtype': 'uint8', 'nodata': 0.0, 'width': 791, 'height': 718, 'count': 3, 'crs': CRS.from_epsg(32618), 'transform': Affine(300.0379266750948, 0.0, 101985.0,
#       0.0, -300.041782729805, 2826915.0), 'tiled': False, 'interleave': 'pixel'}
```