### PR TITLE
DOC: add grib

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ data drivers included in this package.
 
 In `intake-xarray`, there are plugins provided for reading data into [xarray](http://xarray.pydata.org/en/stable/) 
 containers:
-  - NetCDF
+  - NetCDF (also handles other file formats which can be passed to xarray.open_dataset such as grib)
   - OPeNDAP
   - Rasterio
   - Zarr

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ data drivers included in this package.
 
 In `intake-xarray`, there are plugins provided for reading data into [xarray](http://xarray.pydata.org/en/stable/) 
 containers:
-  - NetCDF (also handles other file formats which can be passed to xarray.open_dataset such as grib)
+  - NetCDF (also handles other file formats which can be passed to
+  [xarray.open_dataset](http://xarray.pydata.org/en/stable/generated/xarray.open_dataset.html) such as grib)
   - OPeNDAP
   - Rasterio
   - Zarr

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -48,8 +48,8 @@ While all the drivers in the ``intake-xarray`` plugin yield ``xarray``
 objects, they do not all accept the same file formats.
 
 
-netcdf
-------
+netcdf/grib
+-----------
 
 Supports any local or downloadable file that can be passed to xarray.open_dataset.
 Remote files will be cached locally.


### PR DESCRIPTION
The text below states this method uses files passed to open_dataset which includes grib files. Wanted to make it a bit more explicit in subtitle