### PR TITLE
Migration from deprecated dask.bytes to fsspec.core

### DIFF
--- a/intake_xarray/image.py
+++ b/intake_xarray/image.py
@@ -332,7 +332,7 @@ class ImageSource(DataSourceMixin, PatternMixin):
         Main entry function that finds a set of files and passes them to the
         reader.
         """
-        from dask.bytes import open_files
+        from fsspec.core import open_files
 
         files = open_files(self.urlpath, **self.storage_options)
         if len(files) == 0:


### PR DESCRIPTION
dask.bytes.open_files is marked deprecated (https://docs.dask.org/en/latest/_modules/dask/bytes.html).
The replacement is in fsspec.core.open_files.
By importing fsspec.core, it should silence/fix the deprecation notice.