### PR TITLE
Clobber on register

### DIFF
--- a/intake_xarray/__init__.py
+++ b/intake_xarray/__init__.py
@@ -12,5 +12,5 @@ from .xarray_container import RemoteXarray
 from .image import ImageSource
 
 
-intake.register_driver('remote-xarray', RemoteXarray)
+intake.register_driver('remote-xarray', RemoteXarray, clobber=True)
 register_container('xarray', RemoteXarray)

--- a/intake_xarray/__init__.py
+++ b/intake_xarray/__init__.py
@@ -12,5 +12,9 @@ from .xarray_container import RemoteXarray
 from .image import ImageSource
 
 
-intake.register_driver('remote-xarray', RemoteXarray, clobber=True)
+try:
+    intake.register_driver('remote-xarray', RemoteXarray)
+except ValueError:
+    pass
+
 register_container('xarray', RemoteXarray)

--- a/intake_xarray/xzarr.py
+++ b/intake_xarray/xzarr.py
@@ -38,6 +38,8 @@ class ZarrSource(DataSourceMixin):
         if "chunks" not in kw:
             kw["chunks"] = {}
         kw["engine"] = "zarr"
+        if self.storage_options and "storage_options" not in kw.get("backend_kwargs", {}):
+            kw.setdefault("backend_kwargs", {})["storage_options"] = self.storage_options
         if isinstance(self.urlpath, list) or "*" in self.urlpath:
             self._ds = xr.open_mfdataset(self.urlpath, **kw)
         else:


### PR DESCRIPTION
Since the entrypoint version may already be in the intake registry

Required by https://github.com/intake/intake/pull/636 , but does no harm for earlier versions