### PR TITLE
sel transform

### DIFF
--- a/intake_xarray/derived.py
+++ b/intake_xarray/derived.py
@@ -1,0 +1,64 @@
+from intake import Schema
+from intake.source.derived import GenericTransform
+
+
+class XArrayTransform(GenericTransform):
+    """Transform where the input and output are both xarray objects.
+    You must supply ``transform`` and any ``transform_kwargs``.
+    """
+
+    input_container = "xarray"
+    container = "xarray"
+    optional_params = {}
+    _ds = None
+
+    def to_dask(self):
+        if self._ds is None:
+            self._pick()
+            self._ds = self._transform(
+                self._source.to_dask(), **self._params["transform_kwargs"]
+            )
+        return self._ds
+
+    def _get_schema(self):
+        """load metadata only if needed"""
+        self.to_dask()
+        return Schema(
+            datashape=None,
+            dtype=None,
+            shape=None,
+            npartitions=None,
+            extra_metadata=self._ds.extra_metadata,
+        )
+
+    def read(self):
+        return self.to_dask().compute()
+
+
+class Sel(XArrayTransform):
+    """Simple array transform to subsample an xarray object using
+    the sel method.
+    Note that you could use XArrayTransform directly, by writing a
+    function to choose the subsample instead of a method as here.
+    """
+
+    input_container = "xarray"
+    container = "xarray"
+    required_params = ["indexers"]
+
+    def __init__(self, indexers, **kwargs):
+        """
+        indexers: dict (stord as str) which is passed to xarray.Dataset.sel
+        """
+        # this class wants required "indexers", but XArrayTransform
+        # uses "transform_kwargs", which we don't need since we use a method for the
+        # transform
+        kwargs.update(
+            transform=self.sel,
+            indexers=indexers,
+            transform_kwargs={},
+        )
+        super().__init__(**kwargs)
+
+    def sel(self, ds):
+        return ds.sel(eval(self._params["indexers"]))

--- a/intake_xarray/tests/data/catalog.yaml
+++ b/intake_xarray/tests/data/catalog.yaml
@@ -114,3 +114,12 @@ sources:
       chunks: {}
       auth: null
       engine: netcdf4
+  xarray_source_sel:
+    description: select subsample of xarray_source entry
+    driver: intake_xarray.derived.XArrayTransform
+    args:
+      targets:
+        - xarray_source
+      transform: "intake_xarray.tests._sel"
+      transform_kwargs:
+        indexers: "dict([('lat', 20)])"

--- a/intake_xarray/tests/data/catalog.yaml
+++ b/intake_xarray/tests/data/catalog.yaml
@@ -120,6 +120,6 @@ sources:
     args:
       targets:
         - xarray_source
-      transform: "intake_xarray.tests._sel"
+      transform: "intake_xarray.tests.test_derived._sel"
       transform_kwargs:
         indexers: "dict([('lat', 20)])"

--- a/intake_xarray/tests/test_derived.py
+++ b/intake_xarray/tests/test_derived.py
@@ -1,0 +1,3 @@
+def _sel(ds, indexers: str):
+    """indexers: dict (stored as str) which is passed to xarray.Dataset.sel"""
+    return ds.sel(eval(indexers))

--- a/intake_xarray/tests/test_derived.py
+++ b/intake_xarray/tests/test_derived.py
@@ -1,3 +1,23 @@
+import os
+import pytest
+
+from intake import open_catalog
+from xarray.tests import assert_allclose
+
+
+# Function used in xarray_source_sel entry in catalog.yaml
 def _sel(ds, indexers: str):
     """indexers: dict (stored as str) which is passed to xarray.Dataset.sel"""
     return ds.sel(eval(indexers))
+
+
+@pytest.fixture
+def catalog():
+    path = os.path.dirname(__file__)
+    return open_catalog(os.path.join(path, "data", "catalog.yaml"))
+
+
+def test_catalog(catalog):
+    expected = catalog["xarray_source"].read().sel(lat=20)
+    actual = catalog["xarray_source_sel"].read()
+    assert_allclose(actual, expected)


### PR DESCRIPTION
Convo started at https://github.com/intake/intake/pull/663

Ready for review

~~I believe I have this working outside of the repo.~~

my_dervied.py:
```
from intake import Schema
from intake.source.derived import GenericTransform


class XArrayTransform(GenericTransform):
    """Transform where the input and output are both xarray objects.
    You must supply ``transform`` and any ``transform_kwargs``.
    """

    input_container = "xarray"
    container = "xarray"
    optional_params = {}
    _ds = None

    def to_dask(self):
        if self._ds is None:
            self._pick()
            self._ds = self._transform(
                self._source.to_dask(), **self._params["transform_kwargs"]
            )
        return self._ds

    def _get_schema(self):
        """load metadata only if needed"""
        self.to_dask()
        return Schema(
            datashape=None,
            dtype=None,
            shape=None,
            npartitions=None,
            extra_metadata=self._ds.extra_metadata,
        )

    def read(self):
        return self.to_dask().compute()


class Sel(XArrayTransform):
    """Simple array transform to subsample an xarray object using
    the sel method.
    Note that you could use XArrayTransform directly, by writing a
    function to choose the subsample instead of a method as here.
    """

    input_container = "xarray"
    container = "xarray"
    required_params = ["indexers"]

    def __init__(self, indexers, **kwargs):
        """
        indexers: dict (stord as str) which is passed to xarray.Dataset.sel
        """
        # this class wants required "indexers", but XArrayTransform
        # uses "transform_kwargs", which we don't need since we use a method for the
        # transform
        kwargs.update(
            transform=self.sel,
            indexers=indexers,
            transform_kwargs={},
        )
        super().__init__(**kwargs)

    def sel(self, ds):
        return ds.sel(eval(self._params["indexers"]))

    
def _sel(ds, indexers: str):
    """indexers: dict (stored as str) which is passed to xarray.Dataset.sel"""
    return ds.sel(eval(indexers))
```

test.yml:
```
metadata:
  version: 1
sources:
  xarray_source:
    description: example xarray source plugin
    driver: netcdf
    args:
      urlpath: 'example_1.nc'
      chunks: {}
      
  xarray_source_sel:
    description: select subsample of xarray_source entry
    driver: my_derived.XArrayTransform
    args:
      targets:
        - xarray_source
      transform: "my_derived._sel"
      transform_kwargs:
        indexers: "dict([('lat', 20)])"
```

<img width="802" alt="Screen Shot 2022-05-22 at 11 43 00 PM" src="https://user-images.githubusercontent.com/17162724/169739143-d18d5c26-3e6b-40f9-8d26-56d97a5c9924.png">