### PR TITLE
Pass engine to xr.open_mfdataset in OpenDapSource

### DIFF
--- a/ci/environment-py310.yml
+++ b/ci/environment-py310.yml
@@ -21,3 +21,4 @@ dependencies:
   - zarr
   - moto < 3
   - s3fs
+  - werkzeug < 2.2.20

--- a/ci/environment-py310.yml
+++ b/ci/environment-py310.yml
@@ -21,4 +21,4 @@ dependencies:
   - zarr
   - moto < 3
   - s3fs
-  - werkzeug < 2.2.20
+  - werkzeug < 2.2.0

--- a/ci/environment-py38.yml
+++ b/ci/environment-py38.yml
@@ -21,3 +21,4 @@ dependencies:
   - zarr
   - moto < 3
   - s3fs
+  - werkzeug < 2.2.20

--- a/ci/environment-py38.yml
+++ b/ci/environment-py38.yml
@@ -21,4 +21,4 @@ dependencies:
   - zarr
   - moto < 3
   - s3fs
-  - werkzeug < 2.2.20
+  - werkzeug < 2.2.0

--- a/ci/environment-py39.yml
+++ b/ci/environment-py39.yml
@@ -21,3 +21,4 @@ dependencies:
   - zarr
   - moto < 3
   - s3fs
+  - werkzeug < 2.2.20

--- a/ci/environment-py39.yml
+++ b/ci/environment-py39.yml
@@ -21,4 +21,4 @@ dependencies:
   - zarr
   - moto < 3
   - s3fs
-  - werkzeug < 2.2.20
+  - werkzeug < 2.2.0

--- a/ci/environment-upstream.yml
+++ b/ci/environment-upstream.yml
@@ -23,6 +23,7 @@ dependencies:
   - intake
   - rioxarray
   - gdal
+  - werkzeug < 2.2.20
   - pip:
        - git+https://github.com/fsspec/filesystem_spec.git
        - git+https://github.com/intake/intake.git

--- a/ci/environment-upstream.yml
+++ b/ci/environment-upstream.yml
@@ -23,7 +23,7 @@ dependencies:
   - intake
   - rioxarray
   - gdal
-  - werkzeug < 2.2.20
+  - werkzeug < 2.2.0
   - pip:
        - git+https://github.com/fsspec/filesystem_spec.git
        - git+https://github.com/intake/intake.git

--- a/intake_xarray/opendap.py
+++ b/intake_xarray/opendap.py
@@ -92,7 +92,7 @@ class OpenDapSource(DataSourceMixin):
         import xarray as xr
 
         if isinstance(self.urlpath, list):
-            self._ds = xr.open_mfdataset(self.urlpath, chunks=self.chunks, **self._kwargs)
+            self._ds = xr.open_mfdataset(self.urlpath, chunks=self.chunks, engine=self.engine, **self._kwargs)
         else:
             store = self._get_store()
             self._ds = xr.open_dataset(store, chunks=self.chunks, **self._kwargs)

--- a/intake_xarray/tests/test_intake_xarray.py
+++ b/intake_xarray/tests/test_intake_xarray.py
@@ -332,6 +332,22 @@ def test_read_opendap_with_auth(auth):
         )
 
 
+def test_read_opendap_mfdataset_with_engine():
+    pytest.importorskip("pydap")
+    from intake_xarray.opendap import OpenDapSource
+    urls = [
+        'http://example.com/opendap/fake1.nc',
+        'http://example.com/opendap/fake2.nc',
+    ]
+    with patch('xarray.open_mfdataset') as open_mfdataset_mock:
+        open_mfdataset_mock.return_value = 'dataset'
+        source = OpenDapSource(urlpath=urls, chunks={}, auth=None, engine='fake-engine')
+        source._open_dataset()
+        retval = source._ds
+        assert open_mfdataset_mock.called_with(urls, chunks={}, engine='fake-engine')
+    assert retval == 'dataset'
+
+
 @pytest.mark.parametrize("auth", ["esgf", "urs"])
 def test_read_opendap_with_auth_netcdf4(auth):
     from intake_xarray.opendap import OpenDapSource

--- a/intake_xarray/tests/test_remote.py
+++ b/intake_xarray/tests/test_remote.py
@@ -159,11 +159,14 @@ def s3_base():
     import shlex
     import subprocess
 
-    proc = subprocess.Popen(shlex.split("moto_server s3 -p %s" % PORT_S3))
+    proc = subprocess.Popen(shlex.split("moto_server s3 -p %s" % PORT_S3),
+                            stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stdin=subprocess.DEVNULL)
 
     timeout = 5
     while timeout > 0:
         try:
+            print("polling for moto server")
+
             r = requests.get(endpoint_uri)
             if r.ok:
                 break
@@ -171,7 +174,9 @@ def s3_base():
             pass
         timeout -= 0.1
         time.sleep(0.1)
+    print("server up")
     yield
+    print("moto done")
     proc.terminate()
     proc.wait()
 

--- a/intake_xarray/tests/test_remote.py
+++ b/intake_xarray/tests/test_remote.py
@@ -149,69 +149,15 @@ def test_http_read_netcdf_simplecache(data_server):
 # S3
 #based on: https://github.com/dask/s3fs/blob/master/s3fs/tests/test_s3fs.py
 test_bucket_name = "test"
-PORT_S3 = 8001
-endpoint_uri = "http://localhost:%s" % PORT_S3
 test_files = ['RGB.byte.tif', 'example_1.nc']
 
-@pytest.fixture()
-def s3_base():
-    # writable local S3 system
-    import shlex
-    import subprocess
-
-    proc = subprocess.Popen(shlex.split("moto_server s3 -p %s" % PORT_S3),
-                            stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stdin=subprocess.DEVNULL)
-
-    timeout = 5
-    while timeout > 0:
-        try:
-            print("polling for moto server")
-
-            r = requests.get(endpoint_uri)
-            if r.ok:
-                break
-        except:
-            pass
-        timeout -= 0.1
-        time.sleep(0.1)
-    print("server up")
-    yield
-    print("moto done")
-    proc.terminate()
-    proc.wait()
-
-
-@pytest.fixture(scope='function')
-def aws_credentials():
-    """Mocked AWS Credentials for moto."""
-    os.environ['AWS_ACCESS_KEY_ID'] = 'testing'
-    os.environ['AWS_SECRET_ACCESS_KEY'] = 'testing'
-    os.environ['AWS_SECURITY_TOKEN'] = 'testing'
-    os.environ['AWS_SESSION_TOKEN'] = 'testing'
-
-
-@pytest.fixture()
-def s3(s3_base, aws_credentials):
-    ''' anonymous access local s3 bucket for testing '''
-    from botocore.session import Session
-    session = Session()
-    client = session.create_client("s3", endpoint_url=endpoint_uri)
-    client.create_bucket(Bucket=test_bucket_name, ACL="public-read")
-
-    for file_name in [os.path.join(DIRECTORY,x) for x in test_files]:
-        with open(file_name, 'rb') as f:
-            data = f.read()
-            key = os.path.basename(file_name)
-            client.put_object(Bucket=test_bucket_name, Key=key, Body=data)
-
-    # Make sure cache not being used
-    s3fs.S3FileSystem.clear_instance_cache()
-    s3 = s3fs.S3FileSystem(anon=True, client_kwargs={"endpoint_url": endpoint_uri})
-    s3.invalidate_cache()
-    yield
+from s3fs.tests.test_s3fs import s3, s3_base, endpoint_uri
 
 
 def test_s3_list_files(s3):
+    for x in test_files:
+        file_name = os.path.join(DIRECTORY,x)
+        s3.put(file_name, f"{test_bucket_name}/{x}")
     s3 = s3fs.S3FileSystem(anon=True, client_kwargs={"endpoint_url": endpoint_uri})
     files = s3.ls(test_bucket_name)
     assert len(files) > 0
@@ -221,6 +167,9 @@ def test_s3_list_files(s3):
 def test_s3_read_rasterio(s3):
     # Lots of GDAL Environment variables needed for this to work !
     # https://gdal.org/user/virtual_file_systems.html#vsis3-aws-s3-files
+    for x in test_files:
+        file_name = os.path.join(DIRECTORY,x)
+        s3.put(file_name, f"{test_bucket_name}/{x}")
     os.environ['AWS_NO_SIGN_REQUEST']='YES'
     os.environ['AWS_S3_ENDPOINT'] = endpoint_uri.lstrip('http://')
     os.environ['AWS_VIRTUAL_HOSTING']= 'FALSE'
@@ -238,6 +187,9 @@ def test_s3_read_rasterio(s3):
 
 
 def test_s3_read_netcdf(s3):
+    for x in test_files:
+        file_name = os.path.join(DIRECTORY,x)
+        s3.put(file_name, f"{test_bucket_name}/{x}")
     url = f's3://{test_bucket_name}/example_1.nc'
     s3options = dict(client_kwargs={"endpoint_url": endpoint_uri})
     source = intake.open_netcdf(url,


### PR DESCRIPTION
When `OpenDapSource._open_dataset` is called when `urlpath` is a list of
OPeNDAP URLs, no engine is specified in the call to` xr.open_mfdataset`
even if engine is set in the class. This prevents clients from using a
specified engine and reverts to xarray's default engine selection.

This commit changes the call to `xr.open_mfdataset` to include the engine
argument as the `self.engine` value.