### PR TITLE
Remove CI warnings

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,10 +16,10 @@ jobs:
         CONDA_ENV: [py310, py38, py39, upstream]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup conda
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: ci/environment-${{ matrix.CONDA_ENV }}.yml
 

--- a/.github/workflows/pypipublish.yaml
+++ b/.github/workflows/pypipublish.yaml
@@ -8,9 +8,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.x"
       - name: Install dependencies

--- a/ci/environment-py38.yml
+++ b/ci/environment-py38.yml
@@ -13,7 +13,7 @@ dependencies:
   - pip
   - pydap
   - pytest
-  - rasterio
+  - rasterio <= 1.3.6
   - s3fs >= 2021.08.0
   - scikit-image
   - rangehttpserver

--- a/intake_xarray/tests/test_image.py
+++ b/intake_xarray/tests/test_image.py
@@ -125,7 +125,7 @@ def test_coerce_shape_array_non_int():
     expected = np.append(array[:2, :], [[0], [0]], axis=1)
     actual = _coerce_shape(array, shape)
     assert (expected == actual).all()
-    assert expected.dtype == "float"
+    assert expected.dtype == np.float64
 
 
 def test_read_image():

--- a/intake_xarray/tests/test_remote.py
+++ b/intake_xarray/tests/test_remote.py
@@ -69,7 +69,7 @@ def test_http_read_rasterio(data_server):
     assert ("+init" in da.attrs.get('crs', "") or "+proj" in da.attrs.get('crs', "") or
             "PROJCS" in da.spatial_ref.attrs["crs_wkt"])
     assert da.attrs['AREA_OR_POINT'] == 'Area'
-    assert da.dtype == 'uint8'
+    assert da.dtype == np.uint8
     assert da.isel(band=2,x=300,y=500).values == 129
 
 
@@ -236,7 +236,7 @@ def test_s3_read_rasterio(s3):
     assert ("+init" in da.attrs.get('crs', "") or "+proj" in da.attrs.get('crs', "") or
             "PROJCS" in da.spatial_ref.attrs["crs_wkt"])
     assert da.attrs['AREA_OR_POINT'] == 'Area'
-    assert da.dtype == 'uint8'
+    assert da.dtype == np.uint8
     assert da.isel(band=2,x=300,y=500).values == 129
 
 

--- a/intake_xarray/tests/test_remote.py
+++ b/intake_xarray/tests/test_remote.py
@@ -49,7 +49,7 @@ def data_server():
 def test_http_server_files(data_server):
     test_files = ['RGB.byte.tif', 'example_1.nc', 'example_2.nc', 'little_green.tif', 'little_red.tif']
     h = fsspec.filesystem("http")
-    out = h.glob(data_server + '/')
+    out = h.glob(data_server + '/*')
     assert len(out) > 0
     assert set([data_server+'/'+x for x in test_files]).issubset(set(out))
 

--- a/intake_xarray/tests/test_remote.py
+++ b/intake_xarray/tests/test_remote.py
@@ -1,6 +1,7 @@
 # Tests for intake-server, local HTTP file server, local "S3" object server
 import aiohttp
 import intake
+import numpy as np
 import os
 import pytest
 import requests
@@ -122,7 +123,7 @@ def test_http_read_netcdf(data_server):
     url = f'{data_server}/example_1.nc'
     source = intake.open_netcdf(url)
     ds = source.read()
-    assert ds['rh'].isel(lat=0,lon=0,time=0).values.dtype == 'float32'
+    assert ds['rh'].isel(lat=0,lon=0,time=0).values.dtype == np.float32
     assert ds['rh'].isel(lat=0,lon=0,time=0).values == 0.5
 
 
@@ -245,7 +246,7 @@ def test_s3_read_netcdf(s3):
     source = intake.open_netcdf(url,
                                 storage_options=s3options)
     ds = source.read()
-    assert ds['rh'].isel(lat=0,lon=0,time=0).values.dtype == 'float32'
+    assert ds['rh'].isel(lat=0,lon=0,time=0).values.dtype == np.float32
     assert ds['rh'].isel(lat=0,lon=0,time=0).values == 0.5
 
 


### PR DESCRIPTION
Remove warnings in CI:

- Replace deprecated `mamba-org/provision-with-micromamba` with `mamba-org/setup-micromamba`.
- Update versions of actions that are using deprecated `node12`.